### PR TITLE
Task 7: Add authorizer to import endpoint

### DIFF
--- a/bin/shop-angular.backend.ts
+++ b/bin/shop-angular.backend.ts
@@ -4,12 +4,22 @@ import * as cdk from 'aws-cdk-lib';
 import {ApiGatewayStack} from '../lib/api-gateway/api-gateway-stack';
 import {ImportServiceStack} from '../lib/import-service/import-service-stack';
 import {ProductServiceStack} from '../lib/product-service/product-service-stack';
+import {AuthorizationServiceStack} from '../lib/authorization-service/authorization-service-stack';
+import {HttpMethod} from 'aws-cdk-lib/aws-events';
 
 const app = new cdk.App();
 
+// Authorization service stack
+const authorizationService = new AuthorizationServiceStack(app, 'ProductsAuthorizationServiceStack');
+
 // Gateway stack
-const apiGateway = new ApiGatewayStack(app, 'ProductApiGateway');
+const apiGateway = new ApiGatewayStack(app, 'ProductApiGateway', authorizationService.basicAuthorizerArn);
 
 // Gateway Lambda stacks
-new ProductServiceStack(app, 'ProductServiceStack', apiGateway);
-new ImportServiceStack(app, 'ImportServiceStack', apiGateway);
+const productService = new ProductServiceStack(app, 'ProductServiceStack');
+apiGateway.addLambda(productService.getProductLambda, ['{productId}'], HttpMethod.GET, [], []);
+apiGateway.addLambda(productService.getProductsLambda, [], HttpMethod.GET, [], []);
+apiGateway.addLambda(productService.createProductLambda, [], HttpMethod.POST, [], ['title', 'description', 'price']);
+
+const importService = new ImportServiceStack(app, 'ImportServiceStack');
+apiGateway.addLambda(importService.importProductsFileLambda, ['import'], HttpMethod.GET, ['fileName'], [], true);

--- a/example.env
+++ b/example.env
@@ -1,3 +1,4 @@
 PRODUCT_TABLE_NAME=ProductsTable
 STOCK_TABLE_NAME=StockTable
 IMPORT_SERVICE_BUCKET_NAME=import-service-bucket
+USERS=username=PASSWORD,anotheruser=ANOTHER_PASSWORD

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest'
   },
   moduleNameMapper: {
-    '^services/(.*)$': '<rootDir>/lib/services/$1',
+    '^services/(.*)$': '<rootDir>/lib/common/services/$1',
+    '^utils/(.*)$': '<rootDir>/lib/common/utils/$1',
   },
 };

--- a/lib/authorization-service/authorization-service-stack.ts
+++ b/lib/authorization-service/authorization-service-stack.ts
@@ -1,0 +1,30 @@
+import * as cdk from 'aws-cdk-lib';
+import {Construct} from 'constructs';
+import {config} from 'dotenv';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import {parseUsersFromEnv} from '../common/utils/parse-users-from-env';
+import {generateLambdaProps} from '../common/utils/generate-lambda-props';
+
+config();
+
+export class AuthorizationServiceStack extends cdk.Stack {
+  private readonly basicAuthorizerLambda: lambda.Function;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {});
+
+    const users = parseUsersFromEnv(process.env.USERS!);
+
+    this.basicAuthorizerLambda = new lambda.Function(
+      this,
+      'BasicAuthorizerLambda',
+      generateLambdaProps('dist/authorization-service', 'basic-authorizer-handler.main', {
+        ...users,
+      }),
+    );
+  }
+
+  get basicAuthorizerArn(): string {
+    return this.basicAuthorizerLambda.functionArn;
+  }
+}

--- a/lib/authorization-service/basic-authorizer-handler.spec.ts
+++ b/lib/authorization-service/basic-authorizer-handler.spec.ts
@@ -1,0 +1,65 @@
+import { APIGatewayAuthorizerResult, APIGatewayTokenAuthorizerEvent } from 'aws-lambda';
+
+/**
+ * Generates an IAM policy.
+ * @param effect - The policy effect ("Allow" or "Deny").
+ * @param resource - The resource ARN.
+ * @returns The IAM policy.
+ */
+function generatePolicy(effect: 'Allow' | 'Deny', resource: string): APIGatewayAuthorizerResult {
+  return {
+    principalId: 'user',
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Main handler for the Basic Authorizer Lambda.
+ * @param event - The API Gateway Token Authorizer event.
+ * @returns The authorizer result.
+ */
+export async function main(event: APIGatewayTokenAuthorizerEvent): Promise<APIGatewayAuthorizerResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
+  try {
+    const token = event.authorizationToken;
+
+    if (!token || !token.startsWith('Basic ')) {
+      console.log('Unauthorized: No Basic Authorization token provided');
+      throw new Error('Unauthorized');
+    }
+
+    // Decode the Basic Authorization token
+    const base64Credentials = token.split(' ')[1];
+    const decodedCredentials = Buffer.from(base64Credentials, 'base64').toString('utf-8');
+    const [username, password] = decodedCredentials.split(':');
+
+    if (!username || !password) {
+      console.log('Unauthorized: Invalid Basic Authorization token format');
+      throw new Error('Unauthorized');
+    }
+
+    // Validate credentials against environment variables
+    const expectedPassword = process.env[username];
+    if (expectedPassword !== password) {
+      console.log('Access Denied: Invalid credentials');
+      throw new Error('Access Denied');
+    }
+
+    console.log('Access Granted: Valid credentials provided');
+    // Return an IAM policy allowing access
+    return generatePolicy('Allow', event.methodArn);
+  } catch (error) {
+    console.log('Access Denied:', (error instanceof Error ? error : {message: 'who knows'}).message);
+    // Return an IAM policy denying access
+    return generatePolicy('Deny', event.methodArn);
+  }
+}

--- a/lib/authorization-service/basic-authorizer-handler.ts
+++ b/lib/authorization-service/basic-authorizer-handler.ts
@@ -28,10 +28,12 @@ function generatePolicy(effect: 'Allow' | 'Deny', resource: string): APIGatewayA
  * @returns The authorizer result.
  */
 export async function main(event: APIGatewayTokenAuthorizerEvent): Promise<APIGatewayAuthorizerResult> {
+  console.log('Event:', JSON.stringify(event, null, 2));
   try {
     const token = event.authorizationToken;
 
     if (!token || !token.startsWith('Basic ')) {
+      console.log('Unauthorized: No Basic Authorization token provided');
       throw new Error('Unauthorized');
     }
 
@@ -41,18 +43,22 @@ export async function main(event: APIGatewayTokenAuthorizerEvent): Promise<APIGa
     const [username, password] = decodedCredentials.split(':');
 
     if (!username || !password) {
+      console.log('Unauthorized: Invalid Basic Authorization token format');
       throw new Error('Unauthorized');
     }
 
     // Validate credentials against environment variables
     const expectedPassword = process.env[username];
     if (expectedPassword !== password) {
-      throw new Error('Unauthorized');
+      console.log('Access Denied: Invalid credentials');
+      throw new Error('Access Denied');
     }
 
+    console.log('Access Granted: Valid credentials provided');
     // Return an IAM policy allowing access
     return generatePolicy('Allow', event.methodArn);
   } catch (error) {
+    console.log('Access Denied:', (error instanceof Error ? error : {message: 'who knows'}).message);
     // Return an IAM policy denying access
     return generatePolicy('Deny', event.methodArn);
   }

--- a/lib/authorization-service/basic-authorizer-handler.ts
+++ b/lib/authorization-service/basic-authorizer-handler.ts
@@ -1,0 +1,59 @@
+import { APIGatewayAuthorizerResult, APIGatewayTokenAuthorizerEvent } from 'aws-lambda';
+
+/**
+ * Generates an IAM policy.
+ * @param effect - The policy effect ("Allow" or "Deny").
+ * @param resource - The resource ARN.
+ * @returns The IAM policy.
+ */
+function generatePolicy(effect: 'Allow' | 'Deny', resource: string): APIGatewayAuthorizerResult {
+  return {
+    principalId: 'user',
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Main handler for the Basic Authorizer Lambda.
+ * @param event - The API Gateway Token Authorizer event.
+ * @returns The authorizer result.
+ */
+export async function main(event: APIGatewayTokenAuthorizerEvent): Promise<APIGatewayAuthorizerResult> {
+  try {
+    const token = event.authorizationToken;
+
+    if (!token || !token.startsWith('Basic ')) {
+      throw new Error('Unauthorized');
+    }
+
+    // Decode the Basic Authorization token
+    const base64Credentials = token.split(' ')[1];
+    const decodedCredentials = Buffer.from(base64Credentials, 'base64').toString('utf-8');
+    const [username, password] = decodedCredentials.split(':');
+
+    if (!username || !password) {
+      throw new Error('Unauthorized');
+    }
+
+    // Validate credentials against environment variables
+    const expectedPassword = process.env[username];
+    if (expectedPassword !== password) {
+      throw new Error('Unauthorized');
+    }
+
+    // Return an IAM policy allowing access
+    return generatePolicy('Allow', event.methodArn);
+  } catch (error) {
+    // Return an IAM policy denying access
+    return generatePolicy('Deny', event.methodArn);
+  }
+}

--- a/lib/common/utils/generate-lambda-props.ts
+++ b/lib/common/utils/generate-lambda-props.ts
@@ -5,7 +5,7 @@ export function generateLambdaProps(path: string, handler: string, environment: 
   return {
     runtime: lambda.Runtime.NODEJS_20_X,
     memorySize: 1024,
-    timeout: cdk.Duration.seconds(5),
+    timeout: cdk.Duration.seconds(30),
     code: lambda.Code.fromAsset(
       path,
     ),

--- a/lib/common/utils/generate-lambda-props.ts
+++ b/lib/common/utils/generate-lambda-props.ts
@@ -1,0 +1,15 @@
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+
+export function generateLambdaProps(path: string, handler: string, environment: Record<string, string>):  lambda.FunctionProps {
+  return {
+    runtime: lambda.Runtime.NODEJS_20_X,
+    memorySize: 1024,
+    timeout: cdk.Duration.seconds(5),
+    code: lambda.Code.fromAsset(
+      path,
+    ),
+    environment,
+    handler,
+  }
+}

--- a/lib/common/utils/parse-users-from-env.ts
+++ b/lib/common/utils/parse-users-from-env.ts
@@ -1,0 +1,14 @@
+/**
+ * Converts a comma-delimited list into an object representation.
+ * @param input - The comma-delimited string (e.g., "one=TWO,four=FIVE,six=SEVEN").
+ * @returns An object where keys are the left-hand side and values are the right-hand side of the "=".
+ */
+export function parseUsersFromEnv(input: string): Record<string, string> {
+  return input.split(',').reduce<Record<string, string>>((result, pair) => {
+    const [key, value] = pair.split('=');
+    if (key && value) {
+      result[key.trim()] = value.trim();
+    }
+    return result;
+  }, {});
+}


### PR DESCRIPTION
### What's New

- ✅ **Created a new `authorization-service`**  
  Added `authorization-service` alongside `product-service` and `import-service` in the backend repository structure.

- ✅ **Implemented `basicAuthorizer` Lambda function**  
  - This Lambda function handles Basic Authorization by decoding the `Authorization` header and verifying the credentials against environment variables.
  - Credentials are managed securely via a `.env` file, which has been added to `.gitignore` to prevent sensitive data from being committed.
  - It returns:
    - `403 Forbidden` for invalid credentials
    <img width="1621" alt="Screenshot 2025-05-31 at 10 07 26 AM" src="https://github.com/user-attachments/assets/5acd1928-5104-46cb-8b46-3a3e39945a50" />

    - `401 Unauthorized` when the `Authorization` header is missing
    <img width="1621" alt="Screenshot 2025-05-31 at 10 02 45 AM" src="https://github.com/user-attachments/assets/e6633c8b-bb63-4382-ac27-122ca3d4c89a" />

- ✅ **Configured environment variable-based credential management so that multiple users can be added**  
  - Example `.env` entry:  
    ```
    USERS=username=PASSWORD,anotheruser=ANOTHER_PASSWORD
    ```
   - Each of these comma delineated users will be added to the environment according to the requirements.

- ✅ **Added Lambda Authorizer to `/import` path on the Import Service API Gateway**  
  - Integrated `basicAuthorizer` Lambda as the custom authorizer for the `/import` route.
  <img width="1621" alt="Screenshot 2025-05-31 at 10 12 27 AM" src="https://github.com/user-attachments/assets/b6a6e4c9-e6b9-46aa-b548-2a17a3139622" />


